### PR TITLE
Annotate generated builder class with @Generated

### DIFF
--- a/java/com/google/callbuilder/CallBuilderProcessor.java
+++ b/java/com/google/callbuilder/CallBuilderProcessor.java
@@ -245,6 +245,9 @@ public class CallBuilderProcessor extends AbstractProcessor {
           }
 
           writef(wrt, lines(
+              "@javax.annotation.Generated(\"%s\")"),
+              CallBuilderProcessor.class.getName());
+          writef(wrt, lines(
               "public final class %s%s {"),
               className, typeParameters.alligatorWithBounds());
 


### PR DESCRIPTION
This annotation has @Retention(SOURCE) so it is not possibly to write a test for
it unless the test parses the generated code.